### PR TITLE
Ajout d'une méthode pour uploader depuis du contenu

### DIFF
--- a/src/Actions/ManagesUploads.php
+++ b/src/Actions/ManagesUploads.php
@@ -17,4 +17,16 @@ trait ManagesUploads
     {
         return new File($this->upload('files', $fileContent, $payload)['data']);
     }
+
+    /**
+     * Upload un fichier depuis son contenu.
+     * @param string $fileContent le contenu du fichier.
+     * @param string $fileName le nom du fichier (qui sera uploadé sur IBP).
+     * @param array $payload Les données supplémentaires à transmettre.
+     * @return File
+    */
+    public function uploadFileFromContent($fileContent, $fileName, array $payload = [])
+    {
+        return new File($this->uploadFromContent('files', $fileContent, $fileName, $payload)['data']);
+    }
 }


### PR DESCRIPTION
Exemple dans le cas des workflows, on genère le fichier DOT depuis une méthode (pas de fichier)
La méthode ajoutée évite de devoir créer un fichier temporaire pour pouvoir uploader sur IBP



